### PR TITLE
resolve impossible build scenario

### DIFF
--- a/makedeb/PKGBUILD
+++ b/makedeb/PKGBUILD
@@ -19,7 +19,6 @@ optdepends=(
 )
 makedepends=(
     'asciidoctor'
-    'rustup'
     'pkg-config'
 )
 license=('GPL3')


### PR DESCRIPTION
currently, attempting to follow the [official documentation here](https://docs.makedeb.org/using-the-mpr/mist-the-mpr-cli/#from-source) results in the following:

```bash
cobalt@ideapad-flex-5:~$ git clone 'https://mpr.makedeb.org/mist'
cd mist/
makedeb -si -H 'MPR-Package: yes'
Cloning into 'mist'...
remote: Enumerating objects: 61, done.
remote: Counting objects: 100% (61/61), done.
remote: Compressing objects: 100% (61/61), done.
remote: Total 61 (delta 29), reused 0 (delta 0), pack-reused 0
Receiving objects: 100% (61/61), 6.82 KiB | 6.82 MiB/s, done.
Resolving deltas: 100% (29/29), done.
[#] Making package: mist 0.10.0-1 (Sun 04 Dec 2022 08:54:44 PM EST)
[#] Checking for missing dependencies...
[#] Installing missing dependencies...
[sudo] password for cobalt: 
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
Some packages could not be installed. This may mean that you have
requested an impossible situation or if you are using the unstable
distribution that some required packages have not yet been created
or been moved out of Incoming.
The following information may help to resolve the situation:

The following packages have unmet dependencies:
 satisfy:command-line : Depends: rustup but it is not installable
E: Unable to correct problems, you have held broken packages.
[!] Failed to install missing dependencies.
```
I've installed rustup following the script on their [official site](https://rustup.rs/), but makedeb can't see this because it's not installed as an apt package.